### PR TITLE
feat: apply channel to communicate between threads

### DIFF
--- a/src-tauri/src/event_handler.rs
+++ b/src-tauri/src/event_handler.rs
@@ -1,0 +1,20 @@
+use std::sync::mpsc::Receiver;
+
+use crate::{
+    events::UserMetric,
+    sqlite::{insert_afk_log, insert_window_log},
+};
+
+pub fn handle_events(rx: Receiver<UserMetric>) {
+    loop {
+        let metric = rx.recv().unwrap();
+        match metric {
+            UserMetric::AFK(afk_event) => {
+                insert_afk_log(&afk_event);
+            }
+            UserMetric::Window(window_event) => {
+                insert_window_log(&window_event);
+            }
+        }
+    }
+}

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -16,3 +16,8 @@ pub struct WindowInformation {
     pub class: Option<Vec<String>>,
     pub exec_path: Option<String>,
 }
+
+pub enum UserMetric {
+    AFK(AFKEvent),
+    Window(WindowInformation),
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod event_handler;
 pub mod events;
 pub mod initializer;
 pub mod sqlite;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,15 +1,26 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use tauri_plugin_log::LogTarget;
-use tpulse::{initializer::initialize_db, watcher::watch_afk};
+use tpulse::{
+    event_handler::handle_events,
+    events::UserMetric,
+    initializer::initialize_db,
+    watcher::{watch_afk, watch_window},
+};
 
 fn main() {
     initialize_db();
 
-    let afk_watch = thread::spawn(move || watch_afk(5000, 50000));
-    let window_watch = thread::spawn(move || tpulse::watcher::watch_window(1000));
+    let (tx, rx): (Sender<UserMetric>, Receiver<UserMetric>) = mpsc::channel();
+    let afk_tx = tx.clone();
+    let window_tx = tx.clone();
+
+    let afk_watcher = thread::spawn(move || watch_afk(5000, 50000, afk_tx));
+    let window_watcher = thread::spawn(move || watch_window(1000, window_tx));
+    let event_handler = thread::spawn(move || handle_events(rx));
 
     tauri::Builder::default()
         // We cannot see log when running in bundled app.
@@ -25,6 +36,7 @@ fn main() {
         .run(tauri::generate_context!())
         .expect("Error while running tauri application");
 
-    afk_watch.join().unwrap();
-    window_watch.join().unwrap();
+    afk_watcher.join().unwrap();
+    window_watcher.join().unwrap();
+    event_handler.join().unwrap();
 }

--- a/src-tauri/src/watcher/window.rs
+++ b/src-tauri/src/watcher/window.rs
@@ -1,19 +1,29 @@
 use log::{error, info};
-use std::{thread::sleep, time::Duration};
+use std::{sync::mpsc, thread::sleep, time::Duration};
 
-use crate::sqlite::insert_window_log;
+use crate::events::UserMetric;
 
 use super::window_query::get_current_window_information;
 
-pub fn watch_window(poll_time: u64) {
+/// Watches the current window and sends window information through a channel.
+///
+/// This function continuously polls for window information at a specified interval (`poll_time`)
+/// and sends the information through the provided `tx` channel. The window information is obtained
+/// using the `get_current_window_information` function.
+///
+/// # Arguments
+///
+/// * `poll_time` - The interval in milliseconds at which to poll for window information.
+/// * `tx` - The channel sender to send the window information through.
+pub fn watch_window(poll_time: u64, tx: mpsc::Sender<UserMetric>) {
     info!("Window watcher started !");
     loop {
         sleep(Duration::from_millis(poll_time));
         let window_info = get_current_window_information();
         match window_info {
             std::result::Result::Ok(window_info) => {
-                info!("{:?}", window_info);
-                insert_window_log(&window_info);
+                tx.send(UserMetric::Window(window_info))
+                    .expect("Failed to send window information");
             }
             Err(e) => {
                 error!("Window information error: {}", e);


### PR DESCRIPTION
AFK watcher, window watcher & browser watcher write to channel, while we have an `event handler` to handle incoming metrics.